### PR TITLE
Limit Airtable fetching to first 3 listings

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,8 +46,9 @@ async def get_listings():
     }
     
     try:
-        # Fetch all records from Airtable
-        response = requests.get(AIRTABLE_URL, headers=headers)
+        # Fetch first 3 records from Airtable (default view order)
+        params = {"maxRecords": 3}
+        response = requests.get(AIRTABLE_URL, headers=headers, params=params)
         response.raise_for_status()
         
         data = response.json()


### PR DESCRIPTION
Updates the listings API endpoint to fetch only the first 3 records from Airtable instead of all records, improving performance and providing consistent data for the game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)